### PR TITLE
Changed lightsource process method to return a list of sorted intersections.

### DIFF
--- a/amnesia/classes/lightsource.cpp
+++ b/amnesia/classes/lightsource.cpp
@@ -18,7 +18,7 @@ LightSource::LightSource(Vector position, double radius, double strength)
 
 void LightSource::move(Vector new_position) { position = new_position; }
 
-std::vector<Polygon> LightSource::process(std::vector<Polygon> &polygons) {
+std::vector<Vector> LightSource::process(std::vector<Polygon> &polygons) {
   std::vector<Segment> segments = std::vector<Segment>();
   std::vector<Vector> points = std::vector<Vector>();
   Vector rel_position = position; // + owner->transform;
@@ -86,7 +86,7 @@ std::vector<Polygon> LightSource::process(std::vector<Polygon> &polygons) {
         ray.direction = intersect - ray.anchor;
       }
     }
-    intersections.push_back(Vector(ray.direction));
+    intersections.push_back(Vector(ray.direction + ray.anchor));
   }
 
   // Sort intersects by angle
@@ -94,16 +94,5 @@ std::vector<Polygon> LightSource::process(std::vector<Polygon> &polygons) {
       intersections.begin(), intersections.end(),
       [](const Vector &i, const Vector &j) -> bool { return i.cross(j) > 0; });
 
-  // Calculate light blocks
-  std::vector<Polygon> blocks = std::vector<Polygon>();
-  for (unsigned int i = 0; i < intersections.size(); i++) {
-    std::vector<Vector> triangle_points = std::vector<Vector>();
-    triangle_points.push_back(rel_position);
-    triangle_points.push_back(intersections[i] + rel_position);
-    triangle_points.push_back(intersections[(i + 1) % intersections.size()] +
-                              rel_position);
-    blocks.push_back(Polygon(triangle_points));
-  }
-
-  return blocks;
+  return intersections;
 }

--- a/amnesia/classes/lightsource.h
+++ b/amnesia/classes/lightsource.h
@@ -17,7 +17,7 @@ public:
 
   void move(Vector new_position);
 
-  std::vector<Polygon> process(std::vector<Polygon> &polygons);
+  std::vector<Vector> process(std::vector<Polygon> &polygons);
 
 private:
   Vector position;

--- a/amnesia/classes/renderer.cpp
+++ b/amnesia/classes/renderer.cpp
@@ -1,0 +1,6 @@
+#include "renderer.h"
+
+void Renderer::init() {
+  std::static_pointer_cast<ScriptSystem>(Engine->get_system("script"))
+      ->add_script(shared_from_this());
+}

--- a/amnesia/classes/renderer.h
+++ b/amnesia/classes/renderer.h
@@ -1,0 +1,13 @@
+#ifndef _AMNESIA_RENDERER_HEADER_
+#define _AMNESIA_RENDERER_HEADER_
+
+#include "component.h"
+
+class Renderer : public Component, public std::enable_shared_from_this<Script> {
+
+public:
+  void init() override;
+  virtual void render() = 0;
+};
+
+#endif

--- a/amnesia/classes/shape.cpp
+++ b/amnesia/classes/shape.cpp
@@ -1,0 +1,3 @@
+Shape::Shape() {}
+
+Shape::Shape(std::shared_ptr<Polygon> polygon) {}

--- a/amnesia/classes/shape.h
+++ b/amnesia/classes/shape.h
@@ -1,0 +1,17 @@
+#ifndef _AMNESIA_SHAPE_HEADER_
+#define _AMNESIA_SHAPE_HEADER_
+
+#include "../primitive/polygon.h"
+#include "component.h"
+#include <memory>
+
+class Shape : public Component {
+public:
+  bool light_active;
+  std::shared_ptr<Polygon> polygon;
+
+  Shape();
+  Shape(std::shared_ptr<Polygon> polygon);
+};
+
+#endif

--- a/amnesia/system/renderersystem.cpp
+++ b/amnesia/system/renderersystem.cpp
@@ -1,0 +1,21 @@
+#include "scriptsystem.h"
+
+ScriptSystem::ScriptSystem() : System("script") {}
+
+void ScriptSystem::init() {}
+
+void ScriptSystem::update() {
+  for (auto it = scripts.begin(); it != scripts.end(); it++) {
+    if (auto script = it->lock()) {
+      script->update();
+    } else {
+      it = scripts.erase(it);
+    }
+  }
+}
+
+void ScriptSystem::quit() {}
+
+void ScriptSystem::add_script(std::shared_ptr<Script> script) {
+  scripts.push_back(std::weak_ptr<Script>(script));
+}

--- a/amnesia/system/renderersystem.h
+++ b/amnesia/system/renderersystem.h
@@ -1,0 +1,26 @@
+#ifndef _AMNESIA_SCRIPTSYSTEM_HEADER_
+#define _AMNESIA_SCRIPTSYSTEM_HEADER_
+
+#include "../classes/script.h"
+#include "../core/system.h"
+#include <list>
+#include <memory>
+
+class ScriptSystem : public System {
+
+public:
+  ScriptSystem();
+
+  virtual void init() override;
+
+  virtual void update() override;
+
+  virtual void quit() override;
+
+  void add_script(std::shared_ptr<Script> script);
+
+private:
+  std::list<std::weak_ptr<Script>> scripts;
+};
+
+#endif

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 CXX						:= g++
-CXXFLAGS			:= -Wall -g -pedantic --std=c++11 -stdlib=libc++
+CXXFLAGS			:= -Wall -g -O3 -pedantic --std=c++11 -stdlib=libc++
 BUILDFOLDER 	:= _build
 CPP_FILES 		:= $(shell find ./amnesia -name '*.cpp')
 SRCDIRS 			:= $(patsubst ./%,$(BUILDFOLDER)/%,$(shell find ./amnesia -name '*.cpp' -exec dirname {} \; | uniq))


### PR DESCRIPTION
The purpose for this change is to skip the step to allocate and build
polygons for the renderer which can be simplified to be a fan render
rather than a render of triangles.
